### PR TITLE
Deno (CLI) chores

### DIFF
--- a/.github/workflows/cli-bin.yml
+++ b/.github/workflows/cli-bin.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.19.1
+          deno-version: v1.21.2
 
       - name: Build
         run: deno --unstable compile --no-check --allow-env=NODE_ENV -o dist/dicephrase apps/main-cli/src/main.ts

--- a/apps/main-cli/src/cfg.ts
+++ b/apps/main-cli/src/cfg.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = "0.0.1"
+export const CLI_VERSION = "0.0.2"

--- a/apps/main-cli/src/deps.ts
+++ b/apps/main-cli/src/deps.ts
@@ -1,4 +1,5 @@
-export * from "https://esm.sh/cac"
+export * from "https://unpkg.com/cac@6.7.12/mod.ts"
+
 export {
   combine_zip,
   make_phrases,
@@ -6,5 +7,8 @@ export {
   make_wl_keys,
   shuffle,
   RANDOM_SEPARATOR_OPTS
-} from "../../../pkgs/gen-utils/dist/gen-utils.mod.js"
-export * from "https://deno.land/std@0.126.0/crypto/mod.ts"
+} from 
+// Using the bundled assets instead of source bc the generated TS
+// source would break deno since the imports lack extension specifiers
+// Maybe import maps can help this?
+"../../../pkgs/gen-utils/dist/gen-utils.mod.js"


### PR DESCRIPTION
- Remove old deps
  - No longer need to pass the crypto impl getter function that required that dep.
- Upgrade deno to latest
- Prefer unpkg as cdn
  - May have been caused by the upgrade the deno version, but unpkg is better and didn't cause issues like esm.sh :/ 
  
 Shrunk the emitted size of the executable a bit too :D
 From 84.2 MB to 74.9 MB
<img width="549" alt="MacOS finder view showing size of executable between the two versions. Reduced the size of binary from 84.2 MB to 74.9 MB" src="https://user-images.githubusercontent.com/17863654/167312450-d678f822-32fb-46e0-8a94-f0895f92aa66.png">
 