### PR TITLE
Read environment variables and use multiple domains 

### DIFF
--- a/Dockerfile.ocaml
+++ b/Dockerfile.ocaml
@@ -25,5 +25,6 @@ RUN set -x && \
   chown app:app /home/app/server.exe
 
 WORKDIR /home/app
-EXPOSE 8080
+ENV PORT=8080
+EXPOSE $PORT
 ENTRYPOINT ["/home/app/server.exe"]

--- a/apps/ocaml/bin/server.ml
+++ b/apps/ocaml/bin/server.ml
@@ -62,8 +62,9 @@ let connection_handler ~wl ({ request; _ } : Request_info.t Server.ctx) =
       Response.of_string ~headers `Not_found ~body:""
 
 let run ~sw ~host ~port env handler =
+  let domains = Domain.recommended_domain_count () in
   let config =
-    Server.Config.create ~buffer_size:0x1000 ~domains:1 (`Tcp (host, port))
+    Server.Config.create ~buffer_size:0x1000 ~domains (`Tcp (host, port))
   in
   let server = Server.create ~config handler in
   let command = Server.Command.start ~sw env server in


### PR DESCRIPTION
- Add support for reading env vars for PORT
- Add support for specifying domain count with fallback of `Domain.recommended_domain_count`